### PR TITLE
Updated indproject handling.

### DIFF
--- a/data/projectData.json
+++ b/data/projectData.json
@@ -29,6 +29,7 @@
     "timeframe":        "1 week",
     "problems":         "Using a GET request did not allow us to manipulate NOAA API data. To overcome this we created a proxy server. Originally Firebase was used as the database and host but because of Firebase hosting shortcomings we used Heroku to host.",
     "contributions":    "Accessed NOAA API, parsing and reformatting into user friendly data chucks for addition to a package.json file using JavaScript.",
-    "img":              "images/ebb-tracker.png"
+    "img":              "images/ebb-tracker.png",
+    "projectUrl":       "http://ebb-tracker.herokuapp.com"
   }
 ]

--- a/index.html
+++ b/index.html
@@ -18,23 +18,18 @@
       <h3>{{title}}</h3>
       <section>
         <action class="project-img">
-          <a href="/projects/{{title}}"><img src="{{img}}" alt="{{title}}"></a>
+          <!-- This data-link attribute will be used to update the href in the indprojectController -->
+          <a data-link="{{projectUrl}}" href="/projects/{{title}}"><img src="{{img}}" alt="{{title}}"></a>
         </action>
         <action>
-        </action>
-      </section>
-    </header>
-  </script>
-
-  <script id="indproject-template" type="text/x-handlebars-template">
-    <header>
-      <h3>{{title}}</h3>
-      <section>
-        <action class="project-img">
-          <a href="{{projectUrl}}"><img src="{{img}}" alt="{{title}}"></a>
-        </action>
-        <action>
+          <!-- Assuming you will want this styled differently, but for functionality purposes,
+               everything has been wrapped in paragraph tags. -->
           <p>{{appdesc}}</p>
+          <p>{{background}}</p>
+          <p>{{techused}}</p>
+          <p>{{timeframe}}</p>
+          <p>{{problems}}</p>
+          <p>{{contributons}}</p>
         </action>
       </section>
     </header>

--- a/scripts/indprojectController.js
+++ b/scripts/indprojectController.js
@@ -1,10 +1,29 @@
 (function (module) {
   var indprojectController = {};
 
+  // In order to know what project to show, we can grab the ctx.params.title value
+  // from our URL, since clicking on a project's image navigates to /projects/title.
+  // We then hide all #project header elements (which is each individual project),
+  // then fade in both the project we want to show, as well as its action element that's
+  // a last child. This action element was originally hidden by the projectController
+  // that fired when the user navigated to the /projects route.
+  // We stored a reference to the project's deployed page in the data-link attribute
+  // in our Handlebars template, so we can update the href accordingly by getting that
+  // value using the jQuery(selector).attr getter. Recall that passing one argument into
+  // the .attr() function gets the value, while passing two arguments into it sets the
+  // value.
   indprojectController.index = function(ctx) {
     let projectToShow = ctx.params.title;
+    // Instead of querying the DOM repeatedly, we can store reference to the element in a variable.
+    // Since it's a jQuery object, we note it by starting the variable with a $.
+    let $projectToShow = $(`#${projectToShow}`);
+    let $anchorElement = $projectToShow.find('a');
+    let newLink = $anchorElement.attr('data-link');
+    
     $('#project header').hide();
-    $(`#${projectToShow}`).fadeIn();
+    $projectToShow.fadeIn();
+    $projectToShow.find('action:last-child').fadeIn();
+    $anchorElement.attr('href', newLink);
   };
 
 

--- a/scripts/projectController.js
+++ b/scripts/projectController.js
@@ -3,10 +3,26 @@
 
   Projects.fetchProjects();
 
+  // When the projects page is loaded, hide all sections with a class of tab-content, then hide all
+  // the action elements that are a last child. This effectively hides the action elements with all
+  // the <p> tags in them.
+  // Then fadeIn both the element with #project (which is the projects section), and all header elements
+  // that are children of #project (which are your three indprojects). Because the action:last-child
+  // element was hidden for each of these projects, we should only see the title and image.
+  // However, since the indprojectController also changes the hrefs to the actual projectURLs, we need
+  // to properly update them back to linking to /projects/title.
+  // So, using jquery(selector).each, we can iterate over each indproject, which is a header element,
+  // and do so. We grab the id, which should be the project's title, then find the anchor tag child
+  // with jquery(selector).find, and update its href to be, as it originally was in our template,
+  // /projects/title.
   projectController.index = function() {
     $('.tab-content').hide();
-    $('#project').fadeIn();
-    $('#project header').fadeIn();
+    $('#project header action:last-child').hide();
+    $('#project, #project header').fadeIn();
+    $('#project header').each(function(i, ele) {
+      let eleTitle = $(ele).attr('id');
+      $(ele).find('a').attr('href', `/projects/${eleTitle}`);
+    });
   };
 
 


### PR DESCRIPTION
Condensed the two templates down into one. Added in functionality for the projectController so that initially loading the projects page shows all titles and images, updating the hrefs on the images (which are nested inside anchor links) to point to /projects/title. Clicking on an image will then fire off page.js and the indprojectController router, which will show more detailed information about each project, as well as update the image href to the deployed site's URL.